### PR TITLE
ci: workflow file for `goimports`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Formatting & Linting
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  goimports:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Run make imports and save output
+        run: |
+          make imports > goimports.txt
+          if [ -s goimports.txt ]; then
+            echo "The following files have import issues and must be fixed:" && cat goimports.txt
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: imports
+
+.SILENT: imports
+
+imports:
+	go run golang.org/x/tools/cmd/goimports@latest -l -w -local traderkit-server .

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+
 	"traderkit-server/utils"
 
 	"github.com/gofiber/fiber/v2"


### PR DESCRIPTION
Creates a `Makefile` that contains an `imports` command that when executed will run `goimports` over the project directory. Additionally includes a GitHub Actions workflow file to automatically check imports for correctness during CI.
