### PR TITLE
chore: create and ignore `data/` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+data/
 .env


### PR DESCRIPTION
Creates a `data/` directory in the root of the project for holding data storage files (such as CSVs) that is gitignored.
