### PR TITLE
feat: retention period calculator

### DIFF
--- a/utils/retention_period.go
+++ b/utils/retention_period.go
@@ -4,9 +4,16 @@ import (
 	"time"
 )
 
-func GetLastRetainedDay(now time.Time, n int) time.Time {
+// LastRetainedDay returns the time.Time in UTC that represents the start of the last day in Eastern Time that should
+// have aggregate bars retained for.
+func LastRetainedDay(now time.Time, n int) time.Time {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		panic(err)
+	}
+
 	i := 0
-	today := now.UTC().Truncate(24 * time.Hour)
+	today := truncateToLocationDay(now.In(loc))
 	curr := today
 
 	for i < n {
@@ -15,5 +22,10 @@ func GetLastRetainedDay(now time.Time, n int) time.Time {
 			i++
 		}
 	}
-	return curr
+
+	return curr.UTC()
+}
+
+func truncateToLocationDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }

--- a/utils/retention_period.go
+++ b/utils/retention_period.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"time"
+)
+
+func GetLastRetainedDay(now time.Time, n int) time.Time {
+	i := 0
+	today := now.UTC().Truncate(24 * time.Hour)
+	curr := today
+
+	for i < n {
+		curr = curr.AddDate(0, 0, -1)
+		if curr.Weekday() != time.Saturday && curr.Weekday() != time.Sunday {
+			i++
+		}
+	}
+	return curr
+}

--- a/utils/retention_period.go
+++ b/utils/retention_period.go
@@ -8,13 +8,13 @@ import (
 
 // LastRetainedDay returns the time.Time in UTC that represents the start of the last day in Eastern Time that should
 // have aggregate bars retained for.
-func LastRetainedDay(now time.Time, n int) time.Time {
+func LastRetainedDay(now time.Time, n uint8) time.Time {
 	loc, err := time.LoadLocation("America/New_York")
 	if err != nil {
 		panic(err)
 	}
 
-	i := 0
+	var i uint8 = 0
 	today := truncateToLocationDay(now.In(loc))
 	curr := today
 

--- a/utils/retention_period.go
+++ b/utils/retention_period.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+	"os"
 	"time"
 )
 
@@ -18,12 +20,49 @@ func LastRetainedDay(now time.Time, n int) time.Time {
 
 	for i < n {
 		curr = curr.AddDate(0, 0, -1)
-		if curr.Weekday() != time.Saturday && curr.Weekday() != time.Sunday {
+		if IsMarketOpenOnDay(curr) {
 			i++
 		}
 	}
 
 	return curr.UTC()
+}
+
+// IsMarketOpenOnDay checks if the given time.Time instance is neither a weekend nor a market holiday, thus data is
+// assumed to be present for the given time.Time's date if `true` is returned.
+func IsMarketOpenOnDay(t time.Time) bool {
+	return t.Weekday() != time.Saturday && t.Weekday() != time.Sunday && !IsMarketHoliday(t)
+}
+
+// IsMarketHoliday checks if the given time.Time instance is on the same date as any of the listed market holidays in
+// the `holidays` slice. This data is sourced manually from https://www.nasdaq.com/market-activity/stock-market-holiday-schedule
+// and should be updated annually. Note that early close dates are not considered holidays.
+func IsMarketHoliday(t time.Time) bool {
+	holidays := []string{
+		"01 January 2025",
+		"20 January 2025",
+		"17 February 2025",
+		"18 April 2025",
+		"26 May 2025",
+		"19 June 2025",
+		"04 July 2025",
+		"01 September 2025",
+		"27 November 2025",
+		"25 December 2025",
+	}
+
+	for _, h := range holidays {
+		ht, err := time.ParseInLocation("02 January 2006", h, t.Location())
+		if err != nil {
+			fmt.Printf("Unable to parse holiday date %s\n", h)
+			os.Exit(1)
+		}
+		if t.Year() == ht.Year() && t.Month() == ht.Month() && t.Day() == ht.Day() {
+			return true
+		}
+	}
+
+	return false
 }
 
 func truncateToLocationDay(t time.Time) time.Time {

--- a/utils/retention_period_test.go
+++ b/utils/retention_period_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+// TestGetLastRetainedDay_IsAThursdayIfGivenASunday. If the current day is a Sunday, and two business days are retained,
+// then it should be expected that Thursday and Friday are retained, as Saturday and Sunday are ignored.
+func TestGetLastRetainedDay_IsAThursdayIfGivenASunday(t *testing.T) {
+	now := time.Date(2025, 7, 13, 0, 0, 0, 0, time.UTC)
+	expected := time.Date(2025, 7, 10, 0, 0, 0, 0, time.UTC) // Thursday before the weekend
+	result := GetLastRetainedDay(now, 2)
+
+	if !result.Equal(expected) {
+		t.Errorf("Expected %v but got %v", expected, result)
+	}
+}
+
+// TestGetLastRetainedDay_IsAWednesdayIfGivenAFriday. If the current day is the middle of Friday, and two business days
+// are retained, then we expect Wednesday and Thursday are trained, as Friday is not complete yet.
+func TestGetLastRetainedDay_IsAWednesdayIfGivenAFriday(t *testing.T) {
+	now := time.Date(2025, 7, 11, 12, 0, 0, 0, time.UTC)
+	expected := time.Date(2025, 7, 9, 0, 0, 0, 0, time.UTC) // Friday before the weekend
+	result := GetLastRetainedDay(now, 2)
+
+	if !result.Equal(expected) {
+		t.Errorf("Expected %v but got %v", expected, result)
+	}
+}

--- a/utils/retention_period_test.go
+++ b/utils/retention_period_test.go
@@ -5,24 +5,24 @@ import (
 	"time"
 )
 
-// TestGetLastRetainedDay_IsAThursdayIfGivenASunday. If the current day is a Sunday, and two business days are retained,
+// TestLastRetainedDay_IsAThursdayIfGivenASunday. If the current day is a Sunday, and two business days are retained,
 // then it should be expected that Thursday and Friday are retained, as Saturday and Sunday are ignored.
-func TestGetLastRetainedDay_IsAThursdayIfGivenASunday(t *testing.T) {
+func TestLastRetainedDay_IsAThursdayIfGivenASunday(t *testing.T) {
 	now := time.Date(2025, 7, 13, 0, 0, 0, 0, time.UTC)
-	expected := time.Date(2025, 7, 10, 0, 0, 0, 0, time.UTC) // Thursday before the weekend
-	result := GetLastRetainedDay(now, 2)
+	expected := time.Date(2025, 7, 10, 4, 0, 0, 0, time.UTC) // Thursday before the weekend, in UTC.
+	result := LastRetainedDay(now, 2)
 
 	if !result.Equal(expected) {
 		t.Errorf("Expected %v but got %v", expected, result)
 	}
 }
 
-// TestGetLastRetainedDay_IsAWednesdayIfGivenAFriday. If the current day is the middle of Friday, and two business days
+// TestLastRetainedDay_IsAWednesdayIfGivenAFriday. If the current day is the middle of Friday, and two business days
 // are retained, then we expect Wednesday and Thursday are trained, as Friday is not complete yet.
-func TestGetLastRetainedDay_IsAWednesdayIfGivenAFriday(t *testing.T) {
+func TestLastRetainedDay_IsAWednesdayIfGivenAFriday(t *testing.T) {
 	now := time.Date(2025, 7, 11, 12, 0, 0, 0, time.UTC)
-	expected := time.Date(2025, 7, 9, 0, 0, 0, 0, time.UTC) // Friday before the weekend
-	result := GetLastRetainedDay(now, 2)
+	expected := time.Date(2025, 7, 9, 4, 0, 0, 0, time.UTC) // Friday before the weekend
+	result := LastRetainedDay(now, 2)
 
 	if !result.Equal(expected) {
 		t.Errorf("Expected %v but got %v", expected, result)


### PR DESCRIPTION
Introduces three utility functions:

1. `LastRetainedDay` computes the start of the earliest day that should be retained by the applications in the aggregated bar data table—this aids in generating the starting date when backfilling is needed for the entire dataset.
2. `IsMarketOpenOnDay` returns `true` if it's a weekday and not a market holiday, `false` otherwise.
3. `IsMarketHoliday` returns `true` if the provided date falls on a listed market holiday.
